### PR TITLE
Update VPN playbook configuration

### DIFF
--- a/vpn-playbook.yaml
+++ b/vpn-playbook.yaml
@@ -1,19 +1,11 @@
 ---
 - name: Configure server with Docker, SSH, Outline and other tools
   hosts: vpn_host
-  become: yes
-  vars:
-    ssh_port: <>
-    outline_port_1: <>
-    outline_port_2: <>
-    new_username: <>
-    new_password: <>
-    email_recipient: <>
-    telegram_token: <>
-    chat_id: <>
-    admin_ssh_key: <>
+  become: true
+  vars_files:
+    - vault.yml
   tasks:
-    # Установка пакетов
+
     - name: Install essential packages
       apt:
         name:
@@ -23,6 +15,7 @@
           - ufw
         state: present
         update_cache: yes
+
     - name: Install Docker
       block:
         - name: Install dependencies
@@ -31,19 +24,19 @@
               - apt-transport-https
               - ca-certificates
               - curl
-              - gnupg-agent
-              - software-properties-common
+              - gnupg
+              - lsb-release
             state: present
             update_cache: yes
 
-        - name: Add Docker GPG key
-          apt_key:
-            url: https://download.docker.com/linux/ubuntu/gpg
-            state: present
+        - name: Add Docker GPG key if not exists
+          command: bash -c "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker.gpg"
+          args:
+            creates: /usr/share/keyrings/docker.gpg
 
         - name: Add Docker repository
           apt_repository:
-            repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+            repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
             state: present
             update_cache: yes
 
@@ -56,10 +49,11 @@
             state: present
             update_cache: yes
       when: ansible_os_family == 'Debian'
-    # Настройка UFW
+      tags: ['docker']
+
     - name: Configure UFW
       block:
-        - name: Allow multiple ports
+        - name: Allow required ports
           ufw:
             rule: allow
             port: "{{ item.port }}"
@@ -69,14 +63,12 @@
             - { port: "{{ outline_port_1 }}", proto: "tcp" }
             - { port: "{{ outline_port_2 }}", proto: "udp" }
             - { port: "443", proto: "tcp" }
-        
-            
+
         - name: Enable UFW
           ufw:
             state: enabled
             policy: deny
 
-    # Настройка SSH
     - name: Configure SSH
       block:
         - name: Change SSH port
@@ -96,24 +88,21 @@
             - { regexp: '^#?PasswordAuthentication', line: 'PasswordAuthentication no' }
       notify: Restart SSH
 
-    # Управление пользователями
     - name: Create new user
       user:
         name: "{{ new_username }}"
         create_home: yes
         shell: /bin/bash
-        password: "{{ new_password | password_hash('sha512') }}"
+        password: "{{ new_password }}"
 
     - name: Add user to groups
       user:
         name: "{{ new_username }}"
-        groups: "{{ item }}"
+        groups:
+          - sudo
+          - docker
         append: yes
-      loop:
-        - sudo
-        - docker
 
-    # Настройка SSH ключей
     - name: Setup SSH keys
       authorized_key:
         user: "{{ item }}"
@@ -123,19 +112,18 @@
         - "{{ ansible_user }}"
         - "{{ new_username }}"
 
-    # Настройка Docker
     - name: Start Docker service
       systemd:
         name: docker
         state: started
         enabled: yes
 
-    # Установка Outline
     - name: Install Outline Server
       shell: bash -c "$(wget -qO- https://raw.githubusercontent.com/Jigsaw-Code/outline-server/master/src/server_manager/install_scripts/install_server.sh)"
-      register: outline_output
       args:
         executable: /bin/bash
+      register: outline_output
+      failed_when: outline_output.rc != 0
 
     - name: Send notification via Telegram
       uri:
@@ -147,9 +135,8 @@
           text: "Outline Data:\n{{ outline_output.stdout }}"
       when: outline_output.stdout is defined
 
-
   handlers:
     - name: Restart SSH
       service:
-        name: sshd
+        name: ssh
         state: restarted


### PR DESCRIPTION
    Changes from previous version:
    - Changed 'become: yes' to 'become: true'
    - Replaced inline vars with vars_files pointing to vault.yml
    - Updated package dependencies:
      * Replaced gnupg-agent with gnupg
      * Replaced software-properties-common with lsb-release
    - Modified Docker GPG key installation: * Now using curl to pipe GPG key directly to gpg command * Added proper key verification with signed-by in repo configuration
    - Improved UFW configuration section naming
    - Updated user configuration:
      * Simplified group assignment
      * Modified password handling
    - Added error handling for outline installation with failed_when condition
    - Fixed service name from 'sshd' to 'ssh'
    - General cleanup and formatting improvements